### PR TITLE
chore: :hammer: Enforce pnpm use and enhance Windows (PowerShell) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,15 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm -s check",
-    "prepare": "rm -rf ./dist && pnpm -s build",
-    "preinstall": "npx only-allow pnpm",
-    "pnpm:devPreinstall": "node -e \"if (process.env.TYPESYNC_DONE !== 'true') { process.env.TYPESYNC_DONE = 'true'; require('child_process').execSync('pnpx typesync && pnpm i', { stdio: 'inherit' }); }\"",
-    "build": "tsc && tsc-alias",
+    "prepare": "pnpm -s build",
+    "build": "node -e \"require('fs').rmSync('./dist', { recursive: true, force: true });\" && tsc && tsc-alias",
     "check": "run-p -l check:*",
     "check:type": "tsc --noEmit",
-    "check:format": "prettier --no-error-on-unmatched-pattern --check --log-level=warn '.'",
-    "check:lint": "eslint --report-unused-disable-directives --color 'src/**/*.{js,ts}'",
+    "check:format": "prettier --no-error-on-unmatched-pattern --check --log-level=warn \".\"",
+    "check:lint": "eslint --report-unused-disable-directives --color \"src/**/*.{js,ts}\"",
     "fix": "run-s -l check:type fix:*",
-    "fix:format": "prettier --no-error-on-unmatched-pattern --write --log-level=warn '.'",
-    "fix:lint": "eslint --report-unused-disable-directives --fix --color 'src/**/*.{js,ts}'"
+    "fix:format": "prettier --no-error-on-unmatched-pattern --write --log-level=warn \".\"",
+    "fix:lint": "eslint --report-unused-disable-directives --fix --color \"src/**/*.{js,ts}\""
   },
   "keywords": [
     "RFID",
@@ -49,6 +47,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-unused-imports": "^4.1.3",
+    "just-pnpm": "^1.0.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3",
     "tsc-alias": "^1.8.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^4.1.3
         version: 4.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
+      just-pnpm:
+        specifier: ^1.0.2
+        version: 1.0.2
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -787,6 +790,10 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  just-pnpm@1.0.2:
+    resolution: {integrity: sha512-a/LtVYjTy1Z1yBl3kFEsic313J8MZ29ZEAFrw1snFOY7/x6Afy1VO2zAgtAlUjIgexOt8TRCRCXo1J+PABIo/Q==}
     hasBin: true
 
   keyv@4.5.4:
@@ -2093,6 +2100,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  just-pnpm@1.0.2: {}
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
- Switch from `only-allow` to `just-pnpm` (https://github.com/npm/cli/issues/2660#issuecomment-1764148955)
- Correctly specify file patterns for linter and formatter
- Pre-build cleanup using `node` instead of `rm` command
- `typesync` shall be a policy to be executed manually when adding packages